### PR TITLE
nomenclature and display changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "antd": "^2.12.1",
     "axios": "^0.16.2",
+    "bytes": "^2.5.0",
     "history": "^4.6.3",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",

--- a/src/containers/DirectoryOverview.js
+++ b/src/containers/DirectoryOverview.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { Row, Col, Table } from 'antd';
 import { Link } from 'react-router-dom';
 import StoragePieChart from '../components/StoragePieChart';
+import bytes from 'bytes';
 
 const totalReducer = (acc, val) => {
     acc.numOfStorages += 1;
@@ -22,8 +23,8 @@ const dataSourceMapper = (storage) => {
         port: storage.contact[1].port,
         protocol: storage.contact[1].protocol,
         xpub: storage.contact[1].xpub,
-        allocated: storage.capacity.allocated,
-        available: storage.capacity.available,
+        allocated: bytes(storage.capacity.allocated),
+        available: bytes(storage.capacity.available),
         timestamp: storage.timestamp
     });
 }
@@ -54,7 +55,7 @@ const columns = [
         sorter: (a, b) => a.available - b.available
     },
     {
-        title: 'Timestamp',
+        title: 'Last Seen',
         dataIndex: 'timestamp',
         key: 'timestamp',
         sorter: (a, b) => a.timestamp - b.timestamp,
@@ -72,7 +73,7 @@ const DirectoryOverview = ({ isFetching, storages }) => {
 
     const pieData = [
         {name: 'Used', value: ov.totalAllocated - ov.totalAvailable},
-        {name: 'Availabe', value: ov.totalAvailable}
+        {name: 'Available', value: ov.totalAvailable}
     ]        
    
     return (
@@ -90,11 +91,11 @@ const DirectoryOverview = ({ isFetching, storages }) => {
                             <table>
                                 <tbody>
                                     <tr>
-                                        <td className='orc-label'>The number of storages :</td>
+                                        <td className='orc-label'>Storage Nodes Online :</td>
                                         <td>{ov.numOfStorages}</td>
-                                        <td className='orc-label'>Total Allocated :</td>
+                                        <td className='orc-label'>Storage Allocated :</td>
                                         <td>{ov.totalAllocated}</td>
-                                        <td className='orc-label'>Total Available :</td>
+                                        <td className='orc-label'>Storage Available :</td>
                                         <td>{ov.totalAvailable}</td>
                                     </tr>
                                     <tr>

--- a/src/containers/NodeView.js
+++ b/src/containers/NodeView.js
@@ -17,7 +17,7 @@ class NodeView extends React.Component {
         ]
         return (
             <div>
-                <h2>Node View</h2>
+                <h2>{protocol}{hostname}:{port}</h2>
                 <Card>
                     <Row className="orc-row" gutter={24}>
                         <Col span={6}>
@@ -49,18 +49,6 @@ class NodeView extends React.Component {
                                     <tr>
                                         <td className='orc-label'>Available :</td>
                                         <td>{bytes(available)}</td>
-                                    </tr>
-                                    <tr>
-                                        <td className='orc-label'>Protocol :</td>
-                                        <td>{protocol}</td>
-                                    </tr>
-                                    <tr>
-                                        <td className='orc-label'>Host Name :</td>
-                                        <td>{hostname}</td>
-                                    </tr>
-                                    <tr>
-                                        <td className='orc-label'>Port :</td>
-                                        <td>{port}</td>
                                     </tr>
                                     <tr>
                                         <td className='orc-label'>Agent :</td>

--- a/src/containers/NodeView.js
+++ b/src/containers/NodeView.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import { Card, Row, Col } from 'antd';
 import StoragePieChart from '../components/StoragePieChart';
 import { Link } from 'react-router-dom';
+import bytes from 'bytes';
 
 class NodeView extends React.Component {
 
@@ -12,7 +13,7 @@ class NodeView extends React.Component {
         const { nodeId, xpub, index, timestamp, allocated, available, protocol, hostname, port, agent } = this.props;
         const pieData = [
             {name: 'Used', value: allocated - available},
-            {name: 'Availabe', value: available}
+            {name: 'Available', value: available}
         ]
         return (
             <div>
@@ -30,11 +31,11 @@ class NodeView extends React.Component {
                                         <td><Link to={'/node/'+nodeId}>{nodeId}</Link></td>
                                     </tr>
                                     <tr>
-                                        <td className='orc-label'>Parent ID :</td>
+                                        <td className='orc-label'>Shared Identity :</td>
                                         <td><Link to={'/parent/'+xpub}>{xpub}</Link></td>
                                     </tr>
                                     <tr>
-                                        <td className='orc-label'>Index :</td>
+                                        <td className='orc-label'>Derivation Index :</td>
                                         <td>{index}</td>
                                     </tr>
                                     <tr>
@@ -43,11 +44,11 @@ class NodeView extends React.Component {
                                     </tr>
                                     <tr>
                                         <td className='orc-label'>Allocated :</td>
-                                        <td>{allocated}</td>
+                                        <td>{bytes(allocated)}</td>
                                     </tr>
                                     <tr>
                                         <td className='orc-label'>Available :</td>
-                                        <td>{available}</td>
+                                        <td>{bytes(available)}</td>
                                     </tr>
                                     <tr>
                                         <td className='orc-label'>Protocol :</td>

--- a/src/containers/ParentView.js
+++ b/src/containers/ParentView.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Card, Row, Col } from 'antd';
 import NodeView from './NodeView';
+import bytes from 'bytes';
 
 const parentViewReducer = (acc, node) => {
     acc.numOfNodes += 1;
@@ -19,8 +20,11 @@ class ParentView extends React.Component {
             totalAllocated: 0,
             totalAvailable: 0
         }
+
         if(children) {
             ov = children.reduce(parentViewReducer, ov)
+            ov.totalAllocated = bytes(ov.totalAllocated)
+            ov.totalAvailable = bytes(ov.totalAvailable)
         }
 
         return (
@@ -30,13 +34,13 @@ class ParentView extends React.Component {
                 <Card>
                     <Row className="orc-row" gutter={24}>
                         <Col span={8}>
-                            <span>The number of storages: {ov.numOfNodes}</span>
+                            <span>Storage Nodes Online: {ov.numOfNodes}</span>
                         </Col>
                         <Col span={8}>
-                            <span>Total Allocated: {ov.totalAllocated}</span>
+                            <span>Storage Allocated: {ov.totalAllocated}</span>
                         </Col>
                         <Col span={8}>
-                            <span>Total Available: {ov.totalAvailable}</span>
+                            <span>Storage Available: {ov.totalAvailable}</span>
                         </Col>
                     </Row>
                     { children && children.map((node)=> <div key={node.nodeId}><NodeView match={{params:{nodeId: node.nodeId}}}/><br/></div>) }


### PR DESCRIPTION
Fixed some nomenclature and used `bytes` package on NPM to make values human readable

`Total Allocated: 5712306503680` ==> `Storage Allocated: 5.2TB`
`Total Available: 5705368774902` ==> `Storage Available: 5.19TB`
`The number of storages: 39` ==> `Storage Nodes Online: 39`
`Node View` ==> `https://orcjfg52ty6ljv54.onion:443` (remove hostname, port, protocol from data view)
`Timestamp` ==> `Last Seen`
`Index` ==> `Derivation Index`